### PR TITLE
Removes bash warnings when running shortcut-window without arguments

### DIFF
--- a/shortcut-window.sh
+++ b/shortcut-window.sh
@@ -41,7 +41,7 @@ function find_window() {
     echo $winid
 }
 
-if [ $1 == "help" ] || [ $1 == "--help" ]; then
+if [ "$1" == "help" ] || [ "$1" == "--help" ]; then
     cat <<EOF
 shortcut-window.sh command [command-args]
 


### PR DESCRIPTION
This is a very important update changing the output of `shortcut-window.sh` (without parameters)

from:
```
user@system:~/X11-window-scripts$ ./shortcut-window.sh 
./shortcut-window.sh: line 44: [: ==: unary operator expected
./shortcut-window.sh: line 44: [: ==: unary operator expected
Invalid argument:  (use --help to show help)
```

to:
```
user@system:~/X11-window-scripts$ ./shortcut-window.sh 
Invalid argument:  (use --help to show help)
```

Beautiful.